### PR TITLE
Show info on unavailable/interrupted service

### DIFF
--- a/hvv-card.js
+++ b/hvv-card.js
@@ -80,6 +80,18 @@ class HvvCard extends LitElement {
                             `;
                     }
 
+                    if (stateObj.state == 'unavailable') {
+                        return html `
+                            <div>
+                            ${showName && stateObj.attributes['friendly_name']
+                            ? html`
+                                <h2 style="padding-left: 16px;">${stateObj.attributes['friendly_name']} <ha-icon icon="mdi:vector-polyline-remove" style="color: red;"></ha-icon></h2>
+                                `
+                            : ""
+                            }
+                        `;
+                    }
+
                     const today = new Date();
                     const max = this._config.max ? this._config.max : 5;
                     var count = 0;


### PR DESCRIPTION
As of now there will be an error if the state of an Entity is "unavailable" that prevents the card from rendering (`${stateObj.attributes['next'].map` cannot be called on those entities).
This is eg. right now the case with the S2 at station "Stadthausbrücke".

This change displays an icon next to the "friendly_name" (if set) to indicate an outage and renders all other lines regardless.