### PR TITLE
Fix Lovelace capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ HVV Card is available as a custom HACS repository. This is the recommended way t
 ### Manual
 
 1. Download the [hvv-card.js](https://raw.githubusercontent.com/nilstgmd/hvv-card/main/hvv-card.js) to `/config/www/`.
-1. Add the following to resources in your lovelace config or use the [Lovelace configuration UI](https://developers.home-assistant.io/docs/frontend/custom-ui/registering-resources/).:
+1. Add the following to resources in your Lovelace config or use the [Lovelace configuration UI](https://developers.home-assistant.io/docs/frontend/custom-ui/registering-resources/).:
 
 ```yaml
 resources:


### PR DESCRIPTION
## Summary
- standardize the capitalization for the Lovelace resource instructions in `README.md`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68402b3c2d38832ba56472fe4faf9dc2