### PR TITLE
Add Jest test framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,11 @@ show_title: true
 show_name: false
 title: HVV
 ```
+
+## Development
+
+Run the tests with:
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "hvv-card",
+  "version": "0.0.1",
+  "description": "Test setup for hvv-card",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^23.0.0"
+  }
+}

--- a/tests/hvv-card.test.js
+++ b/tests/hvv-card.test.js
@@ -1,0 +1,47 @@
+// jest setup using jsdom environment
+
+describe('hvv-card custom element', () => {
+  beforeAll(() => {
+    // stub customElements and base element used by hvv-card
+    class MockLitElement extends HTMLElement {}
+    // minimal html/css template functions
+    MockLitElement.prototype.html = (strings, ...vals) => {
+      let out = '';
+      for (let i = 0; i < strings.length; i++) {
+        out += strings[i];
+        if (i < vals.length) {
+          let v = vals[i];
+          if (Array.isArray(v)) v = v.join('');
+          out += v;
+        }
+      }
+      return out;
+    };
+    MockLitElement.prototype.css = MockLitElement.prototype.html;
+
+    class HaPanelLovelace extends MockLitElement {}
+    customElements.define('ha-panel-lovelace', HaPanelLovelace);
+  });
+
+  test('defines hvv-card element', async () => {
+    await import('../hvv-card.js');
+    expect(customElements.get('hvv-card')).toBeDefined();
+  });
+
+  test('render shows unavailable warning icon', async () => {
+    await import('../hvv-card.js');
+    const card = document.createElement('hvv-card');
+    card.setConfig({ entities: ['sensor.unavail'] });
+    card.hass = {
+      states: {
+        'sensor.unavail': {
+          state: 'unavailable',
+          attributes: { friendly_name: 'Test Entity' }
+        }
+      }
+    };
+
+    const output = card.render();
+    expect(String(output)).toContain('mdi:vector-polyline-remove');
+  });
+});


### PR DESCRIPTION
## Summary
- add `package.json` with Jest and jsdom
- create `tests/hvv-card.test.js` to load the card and check behaviour
- document test command in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402b4b25c0832bba3fb018a11b9dd1