### PR TITLE
Display delay minutes in parentheses

### DIFF
--- a/hvv-card.js
+++ b/hvv-card.js
@@ -231,13 +231,13 @@ class HvvCard extends LitElement {
                                                             departureMins
                                                     }
                                                     ${delay_minutes > 0 ?
-                                                        html`<span class="delay_minutes">+${delay_minutes}</span>` :
+                                                        html`(<span class="delay_minutes">+${delay_minutes}</span>` :
                                                         ``}
                                                     ${delay_minutes <= 0 && this._config.show_time ?
                                                         `` :
                                                         departureHours > 0 ?
-                                                            `h:min` :
-                                                            `min`
+                                                            `h:min)` :
+                                                            `min)`
                                                     }
                                                 `
                                             }


### PR DESCRIPTION
## Summary

The API's departure time already includes delays. I think it is clearer if the delay is shown in parentheses to account for this.

Example: Train's planned departure is 12:03 with current delay of 2 minutes. This would currently be shown as `12:05 +2 min`. I propose to change this to `12:05 (+2 min)`.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] CI/CD or build changes

## Changes Made

- Add parenthesis around delay time

## Checklist

<!-- Mark completed items with an "x" -->

- [x] I have tested my changes locally
- [x] I have run `npm test` and all tests pass
- [ ] I have added tests for new functionality (if applicable)
- [ ] I have updated the README.md (if applicable)
- [ ] My code follows the project's code style
- [ ] I have added comments to my code where necessary